### PR TITLE
DEL-63: Update footer copyright year to 2026

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
   return <div className="pt-4 flex h-full flex-col justify-center">
               <SocialLinks />
     <div className="flex flex-row justify-center mt-3">
-      © 2017-2025 Neil Millard
+      © 2017-2026 Neil Millard
     </div>
     <div className="text-xs text-gray-500 h-10 mt-2 text-center">
       <a href="/privacy" className="hover:text-gray-300">Privacy Policy</a> - <a

--- a/src/app/tests/Footer.test.tsx
+++ b/src/app/tests/Footer.test.tsx
@@ -1,0 +1,14 @@
+import "@testing-library/jest-dom";
+import {describe, test} from "@jest/globals";
+import {cleanup, render, screen} from "@testing-library/react";
+import {Footer} from "@/app/components/Footer";
+
+describe("Footer", () => {
+  test("displays the copyright notice with the current end year", () => {
+    render(<Footer />);
+
+    expect(screen.getByText("© 2017-2026 Neil Millard")).toBeInTheDocument();
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- Updates the footer copyright notice on neilmillard.com from "© 2017-2025" to "© 2017-2026"
- Adds a test for the Footer component covering the copyright text

## Test plan
- [x] `npx jest Footer.test.tsx` passes
- [x] Full suite `npx jest` passes (40/40)
- [x] `npx eslint` clean on changed files