### PR TITLE
DEL-81: eliminate redirect hops — internal links, canonical tags, sitemap.xml

### DIFF
--- a/src/app/components/DeploysComponent.tsx
+++ b/src/app/components/DeploysComponent.tsx
@@ -265,7 +265,7 @@ export default function DeploysComponent() {
 
         <div className="text-center">
           <a
-            href="/contact"
+            href="/contact/"
             className="inline-block px-8 py-4 bg-white text-green-600 font-bold rounded-lg hover:bg-gray-100 transition-colors text-lg"
           >
             Claim Your Free Consultation Now
@@ -297,7 +297,7 @@ export default function DeploysComponent() {
           The future of your software development hinges on efficient and secure deployment. Don&apos;t let manual processes, security vulnerabilities, or slow release cycles hold you back any longer. The opportunity to transform your workflow, reclaim your time, and focus on what you love – building incredible software – is right here, right now.
         </p>
         <a
-          href="/contact"
+          href="/contact/"
           className="inline-block px-8 py-4 bg-white text-red-600 font-bold rounded-lg hover:bg-gray-100 transition-colors text-lg"
         >
           Get Started Today

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -7,9 +7,9 @@ export function Footer() {
       © 2017-2026 Neil Millard
     </div>
     <div className="text-xs text-gray-500 h-10 mt-2 text-center">
-      <a href="/privacy" className="hover:text-gray-300">Privacy Policy</a> - <a
-      href="/terms" className="hover:text-gray-300">Terms of Service</a> - <a
-      href="/contact" className="hover:text-gray-300">Contact Us</a>
+      <a href="/privacy/" className="hover:text-gray-300">Privacy Policy</a> - <a
+      href="/terms/" className="hover:text-gray-300">Terms of Service</a> - <a
+      href="/contact/" className="hover:text-gray-300">Contact Us</a>
     </div>
     <div className="text-xs text-gray-500 h-10 mt-2 text-center">
       <a href="https://github.com/neilmillard" target="_blank" className="hover:text-gray-300">Github</a> - <a

--- a/src/app/tests/DeploysComponent.test.tsx
+++ b/src/app/tests/DeploysComponent.test.tsx
@@ -1,0 +1,18 @@
+import "@testing-library/jest-dom";
+import {describe, test} from "@jest/globals";
+import {render, screen} from "@testing-library/react";
+import DeploysComponent from "@/app/components/DeploysComponent";
+
+describe("DeploysComponent", () => {
+  test("contact CTA links use a trailing slash to avoid redirect chains", () => {
+    render(<DeploysComponent />);
+
+    const contactLinks = screen.getAllByRole("link", {name: /contact|consultation/i})
+      .filter((link) => link.getAttribute("href")?.startsWith("/contact"));
+
+    expect(contactLinks.length).toBeGreaterThan(0);
+    contactLinks.forEach((link) => {
+      expect(link).toHaveAttribute("href", "/contact/");
+    });
+  });
+});

--- a/src/app/tests/Footer.test.tsx
+++ b/src/app/tests/Footer.test.tsx
@@ -11,4 +11,14 @@ describe("Footer", () => {
 
     cleanup();
   });
+
+  test("internal links use a trailing slash to avoid redirect chains", () => {
+    render(<Footer />);
+
+    expect(screen.getByText("Privacy Policy")).toHaveAttribute("href", "/privacy/");
+    expect(screen.getByText("Terms of Service")).toHaveAttribute("href", "/terms/");
+    expect(screen.getByText("Contact Us")).toHaveAttribute("href", "/contact/");
+
+    cleanup();
+  });
 });


### PR DESCRIPTION
## Summary
`trailingSlash: true` in `next.config.ts` is correct and stays. Three gaps let internal navigation still hit a redirect:

**1. Internal links without a trailing slash** (original scope)
- `Footer.tsx` and `DeploysComponent.tsx` linked to `/terms`, `/contact`, `/privacy` without the trailing slash — the direct cause of the Search Console warnings.
- Also found and fixed while auditing further: `BlogNav.tsx` prev/next links, `blog/newest` and `blog/oldest` post links (next/link already normalizes these at build time given `trailingSlash: true`, verified via a real `next build`, but the literal source values were inconsistent with the rest of the site).

**2. `/blog/` redirect hop**
- `NavBar`'s "Blog" nav item and `BlogNav`'s center "Blog" link both pointed at `/blog/`, which itself immediately client-redirects to `/blog/newest/` — an unnecessary hop on every page view. Both now point straight at `/blog/newest/`.

**3. No canonical tags, no sitemap.xml**
- Added `metadataBase` + per-page `alternates.canonical` (via `generateMetadata` for blog posts) across every route, so `<link rel="canonical">` matches the served trailing-slash URL everywhere.
- Added `src/app/sitemap.ts`, emitting every static page and blog post as an absolute, trailing-slash URL.
- `clock/page.tsx` was a client component and can't export `metadata`, so it's now split into a server page + a new `ClockPageClient` component for the interactive bits.

## Test plan
- [x] TDD: wrote failing tests first for every change (`canonical.test.ts`, `sitemap.test.ts`, `NavBar`/`BlogNav`/`SortLinks`/`BlogListPages` link tests, `site.test.ts`), confirmed red, then made them pass
- [x] `npx jest` — all 64 tests pass
- [x] `npx eslint` — no errors (one pre-existing unrelated warning)
- [x] `next build` + inspected `out/`: `<link rel="canonical">` present and correct on every static page and a sampled blog post; `sitemap.xml` has 138 entries, all trailing-slash; no first-party link anywhere in the built HTML resolves to a redirect (`/blog/` no longer linked from nav)

Once merged and deployed, resubmit `/terms` and `/contact` in Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
