### PR TITLE
DEL-81: eliminate remaining redirect hops — canonical tags, sitemap.xml, /blog/ links

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,11 @@
+import type {Metadata} from "next";
 import AboutComponent from "@/app/components/AboutComponent";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/about/",
+  },
+};
 
 export default function About() {
     return <AboutComponent />

--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type {Metadata} from "next";
 import {getAdjacentBlogPosts, getAllBlogPosts, getBlogPost} from "@/lib/blogs";
 import BlogPost, {BlogPostShort} from "@/app/components/blog/BlogPost";
 import {BlogNav} from "@/app/components/blog/BlogNav";
@@ -9,6 +10,17 @@ const BLOG_CONTACT_FRAMING: Record<string, string> = {
   "2026-06-28-do-you-really-need-kubernetes":
     "ECS or Kubernetes — still not sure which fits your team? Tell me about your setup and I'll give you an honest answer.",
 };
+
+export async function generateMetadata({params}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const {id} = await params;
+  return {
+    alternates: {
+      canonical: `/blog/${id}/`,
+    },
+  };
+}
 
 export default async function BlogPage({ params, }: {
   params: Promise<{ id: string }>

--- a/src/app/blog/newest/page.tsx
+++ b/src/app/blog/newest/page.tsx
@@ -1,6 +1,13 @@
+import type {Metadata} from "next";
 import Link from "next/link";
 import {getAllBlogPosts} from "@/lib/blogs";
 import SortLinks from "@/app/components/blog/SortLinks";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/blog/newest/",
+  },
+};
 
 export default function BlogIndex() {
   const blogs = getAllBlogPosts("newest");
@@ -12,7 +19,7 @@ export default function BlogIndex() {
       <ul>
         {blogs.map((blog) => (
           <li key={blog.id} className="mb-2">
-            <Link href={`/blog/${blog.id}`} className="text-blue-500 hover:underline">
+            <Link href={`/blog/${blog.id}/`} className="text-blue-500 hover:underline">
               {blog.title}
             </Link>
             <p className="text-sm text-gray-500">{blog.date}</p>

--- a/src/app/blog/oldest/page.tsx
+++ b/src/app/blog/oldest/page.tsx
@@ -1,6 +1,13 @@
+import type {Metadata} from "next";
 import Link from "next/link";
 import {getAllBlogPosts} from "@/lib/blogs";
 import SortLinks from "@/app/components/blog/SortLinks";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/blog/oldest/",
+  },
+};
 
 export default function BlogIndex() {
   const blogs = getAllBlogPosts("oldest");
@@ -12,7 +19,7 @@ export default function BlogIndex() {
       <ul>
         {blogs.map((blog) => (
           <li key={blog.id} className="mb-2">
-            <Link href={`/blog/${blog.id}`} className="text-blue-500 hover:underline">
+            <Link href={`/blog/${blog.id}/`} className="text-blue-500 hover:underline">
               {blog.title}
             </Link>
             <p className="text-sm text-gray-500">{blog.date}</p>

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,4 +1,11 @@
+import type {Metadata} from "next";
 import BookComponent from "@/app/components/BookComponent";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/book/",
+  },
+};
 
 export default function Book() {
     return <BookComponent />

--- a/src/app/clock/page.tsx
+++ b/src/app/clock/page.tsx
@@ -1,40 +1,12 @@
-"use client";
-import ClockComponent from "@/app/components/ClockComponent";
-import {useState} from "react";
-import TimerComponent from "@/app/components/TimerComponent";
+import type {Metadata} from "next";
+import ClockPageClient from "@/app/components/ClockPageClient";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/clock/",
+  },
+};
 
 export default function Clock() {
-  const [isTimerMode, setIsTimerMode] = useState<boolean>(false);
-  const handleClockMode = () => {
-    setIsTimerMode(false);
-  }
-  const handleTimerMode = () => {
-    setIsTimerMode(true);
-  }
-  const clockButtonReadyClass = isTimerMode ? "bg-green-500 hover:bg-green-600" : "bg-gray-500 hover:bg-gray-600";
-  const timerButtonReadyClass = isTimerMode ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600";
-
-  return (
-    <div className="flex flex-col items-center justify-center h-full">
-      <div className="flex space-x-4 pt-4">
-        <button
-          className={timerButtonReadyClass + " text-white font-bold py-2 px-8 rounded-lg text-xl"}
-          onClick={handleClockMode}
-        >
-          Clock
-        </button>
-        <button
-          className={clockButtonReadyClass + " text-white font-bold py-2 px-8 rounded-lg text-xl"}
-          onClick={handleTimerMode}
-        >
-          Timer
-        </button>
-      </div>
-      {!isTimerMode ? (
-        <ClockComponent/>
-      ) : (
-        <TimerComponent/>
-      )}
-    </div>
-  )
+  return <ClockPageClient/>;
 }

--- a/src/app/components/ClockPageClient.tsx
+++ b/src/app/components/ClockPageClient.tsx
@@ -1,0 +1,40 @@
+"use client";
+import ClockComponent from "@/app/components/ClockComponent";
+import {useState} from "react";
+import TimerComponent from "@/app/components/TimerComponent";
+
+export default function ClockPageClient() {
+  const [isTimerMode, setIsTimerMode] = useState<boolean>(false);
+  const handleClockMode = () => {
+    setIsTimerMode(false);
+  }
+  const handleTimerMode = () => {
+    setIsTimerMode(true);
+  }
+  const clockButtonReadyClass = isTimerMode ? "bg-green-500 hover:bg-green-600" : "bg-gray-500 hover:bg-gray-600";
+  const timerButtonReadyClass = isTimerMode ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600";
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <div className="flex space-x-4 pt-4">
+        <button
+          className={timerButtonReadyClass + " text-white font-bold py-2 px-8 rounded-lg text-xl"}
+          onClick={handleClockMode}
+        >
+          Clock
+        </button>
+        <button
+          className={clockButtonReadyClass + " text-white font-bold py-2 px-8 rounded-lg text-xl"}
+          onClick={handleTimerMode}
+        >
+          Timer
+        </button>
+      </div>
+      {!isTimerMode ? (
+        <ClockComponent/>
+      ) : (
+        <TimerComponent/>
+      )}
+    </div>
+  )
+}

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -13,7 +13,7 @@ interface NavLinkItem {
 }
 
 const navLinks: NavLinkItem[] = [
-  {name: ' Blog ', path: '/blog/'},
+  {name: ' Blog ', path: '/blog/newest/'},
   {name: ' About ', path: '/about/'},
   {name: ' Book', path: '/book/'},
   {name: ' Clock ', path: '/clock/'},

--- a/src/app/components/blog/BlogNav.tsx
+++ b/src/app/components/blog/BlogNav.tsx
@@ -5,17 +5,17 @@ export function BlogNav(props: { previous: BlogPostShort | null, next: BlogPostS
   return <div className={"w-[83%] mx-auto mt-6 grid grid-cols-3 text-blue-500"}>
     <div className={"text-left"}>
       {props.previous ? (
-        <Link href={`/blog/${props.previous.id}`} className={"hover:underline"}>
+        <Link href={`/blog/${props.previous.id}/`} className={"hover:underline"}>
           &lt;- {props.previous.title}
         </Link>
       ) : <div/>}
     </div>
     <div className={"text-center"}>
-      <Link href={"/blog/"}>Blog</Link>
+      <Link href={"/blog/newest/"}>Blog</Link>
     </div>
     <div className={"text-right"}>
       {props.next ? (
-        <Link href={`/blog/${props.next.id}`} className="hover:underline">
+        <Link href={`/blog/${props.next.id}/`} className="hover:underline">
           {props.next.title} -&gt;
         </Link>
       ) : <div/>}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,11 @@
+import type {Metadata} from "next";
 import ContactPage from "@/app/components/ContactForm";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/contact/",
+  },
+};
 
 export default function Contact() {
     return <ContactPage apiUrl={"/api/contact"}/>

--- a/src/app/deploys/page.tsx
+++ b/src/app/deploys/page.tsx
@@ -1,4 +1,11 @@
+import type {Metadata} from "next";
 import DeploysComponent from "@/app/components/DeploysComponent";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/deploys/",
+  },
+};
 
 export default function Deploys() {
     return <DeploysComponent />

--- a/src/app/devops/page.tsx
+++ b/src/app/devops/page.tsx
@@ -1,4 +1,11 @@
+import type {Metadata} from "next";
 import DevOpsComponent from "@/app/components/DevOpsComponent";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/devops/",
+  },
+};
 
 export default function DevOps() {
     return <DevOpsComponent />

--- a/src/app/glossary/page.tsx
+++ b/src/app/glossary/page.tsx
@@ -1,4 +1,11 @@
+import type {Metadata} from "next";
 import GlossaryComponent from "@/app/components/GlossaryComponent";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/glossary/",
+  },
+};
 
 export default function Glossary() {
     return <GlossaryComponent />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { GoogleTagManager } from "@next/third-parties/google"
 import {NavBar} from "@/app/components/NavBar";
 import {Footer} from "@/app/components/Footer";
+import {SITE_URL} from "@/lib/site";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -17,8 +18,12 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Neil Millard",
   description: "Blog, Speaker, Author, Contracting and DevOps",
+  alternates: {
+    canonical: "/",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,3 +1,11 @@
+import type {Metadata} from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/privacy/",
+  },
+};
+
 export default function Privacy() {
   return (
     <div className="w-[83%] mx-auto p-8 bg-white rounded-2xl shadow-md mt-10 mb-10">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,33 @@
+import type {MetadataRoute} from "next";
+import {getAllBlogPosts} from "@/lib/blogs";
+import {SITE_URL} from "@/lib/site";
+
+export const dynamic = "force-static";
+
+const STATIC_PATHS = [
+  "/",
+  "/about/",
+  "/blog/newest/",
+  "/blog/oldest/",
+  "/book/",
+  "/clock/",
+  "/contact/",
+  "/deploys/",
+  "/devops/",
+  "/glossary/",
+  "/privacy/",
+  "/terms/",
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticEntries: MetadataRoute.Sitemap = STATIC_PATHS.map((path) => ({
+    url: `${SITE_URL}${path}`,
+  }));
+
+  const blogEntries: MetadataRoute.Sitemap = getAllBlogPosts().map((blog) => ({
+    url: `${SITE_URL}/blog/${blog.id}/`,
+    lastModified: blog.date ?? undefined,
+  }));
+
+  return [...staticEntries, ...blogEntries];
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,3 +1,11 @@
+import type {Metadata} from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/terms/",
+  },
+};
+
 export default function Terms() {
   return (
     <div className="w-[83%] mx-auto p-8 bg-white rounded-2xl shadow-md mt-10 mb-10">

--- a/src/app/tests/BlogListPages.test.tsx
+++ b/src/app/tests/BlogListPages.test.tsx
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom";
+import {describe, test} from "@jest/globals";
+import {render, screen} from "@testing-library/react";
+import BlogNewest from "@/app/blog/newest/page";
+import BlogOldest from "@/app/blog/oldest/page";
+
+jest.mock("next/link", () => {
+  return {
+    __esModule: true,
+    default: ({href, children, ...rest}: {href: string; children: React.ReactNode}) => (
+      <a href={href} {...rest}>{children}</a>
+    ),
+  };
+});
+
+describe("blog listing pages", () => {
+  test("newest listing links to each post with a trailing slash", () => {
+    render(<BlogNewest />);
+
+    const postLinks = screen.getAllByRole("link").filter((link) => {
+      const href = link.getAttribute("href") ?? "";
+      return href.startsWith("/blog/") && href !== "/blog/newest/" && href !== "/blog/oldest/";
+    });
+
+    expect(postLinks.length).toBeGreaterThan(0);
+    postLinks.forEach((link) => {
+      expect(link.getAttribute("href")).toMatch(/\/$/);
+    });
+  });
+
+  test("oldest listing links to each post with a trailing slash", () => {
+    render(<BlogOldest />);
+
+    const postLinks = screen.getAllByRole("link").filter((link) => {
+      const href = link.getAttribute("href") ?? "";
+      return href.startsWith("/blog/") && href !== "/blog/newest/" && href !== "/blog/oldest/";
+    });
+
+    expect(postLinks.length).toBeGreaterThan(0);
+    postLinks.forEach((link) => {
+      expect(link.getAttribute("href")).toMatch(/\/$/);
+    });
+  });
+});

--- a/src/app/tests/BlogNav.test.tsx
+++ b/src/app/tests/BlogNav.test.tsx
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom";
+import {describe, test} from "@jest/globals";
+import {render, screen} from "@testing-library/react";
+import {BlogNav} from "@/app/components/blog/BlogNav";
+
+// next/link normalizes trailing slashes at build time via config that isn't
+// wired up under jest, so mock it to a plain <a> and assert on the href we
+// actually pass in — that's the part this codebase controls.
+jest.mock("next/link", () => {
+  return {
+    __esModule: true,
+    default: ({href, children, ...rest}: {href: string; children: React.ReactNode}) => (
+      <a href={href} {...rest}>{children}</a>
+    ),
+  };
+});
+
+describe("BlogNav", () => {
+  test("previous, next and blog index links use a trailing slash", () => {
+    render(
+      <BlogNav
+        previous={{id: "prev-post", title: "Previous Post", date: "2022-12-31"}}
+        next={{id: "next-post", title: "Next Post", date: "2023-01-02"}}
+      />
+    );
+
+    expect(screen.getByText(/Previous Post/)).toHaveAttribute("href", "/blog/prev-post/");
+    expect(screen.getByText(/Next Post/)).toHaveAttribute("href", "/blog/next-post/");
+    // Go straight to the canonical listing, not through the /blog/ redirect page
+    expect(screen.getByText("Blog")).toHaveAttribute("href", "/blog/newest/");
+  });
+});

--- a/src/app/tests/NavBar.test.tsx
+++ b/src/app/tests/NavBar.test.tsx
@@ -1,0 +1,29 @@
+import "@testing-library/jest-dom";
+import {describe, test} from "@jest/globals";
+import {render, screen} from "@testing-library/react";
+import {NavBar} from "@/app/components/NavBar";
+
+jest.mock("next/link", () => {
+  return {
+    __esModule: true,
+    default: ({href, children, ...rest}: {href: string; children: React.ReactNode}) => (
+      <a href={href} {...rest}>{children}</a>
+    ),
+  };
+});
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+jest.mock("@mantine/hooks", () => ({
+  useViewportSize: () => ({width: 1024, height: 768}),
+}));
+
+describe("NavBar", () => {
+  test("Blog nav link goes straight to the canonical listing, not the /blog/ redirect", () => {
+    render(<NavBar />);
+
+    expect(screen.getByText("Blog").closest("a")).toHaveAttribute("href", "/blog/newest/");
+  });
+});

--- a/src/app/tests/SortLinks.test.tsx
+++ b/src/app/tests/SortLinks.test.tsx
@@ -1,0 +1,22 @@
+import "@testing-library/jest-dom";
+import {describe, test} from "@jest/globals";
+import {render, screen} from "@testing-library/react";
+import SortLinks from "@/app/components/blog/SortLinks";
+
+jest.mock("next/link", () => {
+  return {
+    __esModule: true,
+    default: ({href, children, ...rest}: {href: string; children: React.ReactNode}) => (
+      <a href={href} {...rest}>{children}</a>
+    ),
+  };
+});
+
+describe("SortLinks", () => {
+  test("newest and oldest links use a trailing slash", () => {
+    render(<SortLinks currentSort="newest" />);
+
+    expect(screen.getByText("Newest First")).toHaveAttribute("href", "/blog/newest/");
+    expect(screen.getByText("Oldest First")).toHaveAttribute("href", "/blog/oldest/");
+  });
+});

--- a/src/app/tests/canonical.test.ts
+++ b/src/app/tests/canonical.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, test} from "@jest/globals";
+import {metadata as rootMetadata} from "@/app/layout";
+import {metadata as aboutMetadata} from "@/app/about/page";
+import {metadata as blogNewestMetadata} from "@/app/blog/newest/page";
+import {metadata as blogOldestMetadata} from "@/app/blog/oldest/page";
+import {metadata as bookMetadata} from "@/app/book/page";
+import {metadata as clockMetadata} from "@/app/clock/page";
+import {metadata as contactMetadata} from "@/app/contact/page";
+import {metadata as deploysMetadata} from "@/app/deploys/page";
+import {metadata as devopsMetadata} from "@/app/devops/page";
+import {metadata as glossaryMetadata} from "@/app/glossary/page";
+import {metadata as privacyMetadata} from "@/app/privacy/page";
+import {metadata as termsMetadata} from "@/app/terms/page";
+import {generateMetadata as generateBlogPostMetadata} from "@/app/blog/[id]/page";
+import {SITE_URL} from "@/lib/site";
+
+describe("canonical tags", () => {
+  test("root layout sets a metadataBase matching the site origin and canonicalizes the home page", () => {
+    expect(rootMetadata.metadataBase?.toString()).toBe(`${SITE_URL}/`);
+    expect(rootMetadata.alternates?.canonical).toBe("/");
+  });
+
+  test.each([
+    ["about", aboutMetadata, "/about/"],
+    ["blog/newest", blogNewestMetadata, "/blog/newest/"],
+    ["blog/oldest", blogOldestMetadata, "/blog/oldest/"],
+    ["book", bookMetadata, "/book/"],
+    ["clock", clockMetadata, "/clock/"],
+    ["contact", contactMetadata, "/contact/"],
+    ["deploys", deploysMetadata, "/deploys/"],
+    ["devops", devopsMetadata, "/devops/"],
+    ["glossary", glossaryMetadata, "/glossary/"],
+    ["privacy", privacyMetadata, "/privacy/"],
+    ["terms", termsMetadata, "/terms/"],
+  ])("%s page declares a trailing-slash canonical URL", (_name, metadata, expected) => {
+    expect(metadata.alternates?.canonical).toBe(expected);
+  });
+
+  test("blog post pages declare a canonical URL matching their id", async () => {
+    const metadata = await generateBlogPostMetadata({params: Promise.resolve({id: "some-post"})});
+    expect(metadata.alternates?.canonical).toBe("/blog/some-post/");
+  });
+});

--- a/src/app/tests/site.test.ts
+++ b/src/app/tests/site.test.ts
@@ -1,0 +1,10 @@
+import {describe, expect, test} from "@jest/globals";
+import {SITE_URL, canonicalUrl} from "@/lib/site";
+
+describe("canonicalUrl", () => {
+  test("builds an absolute URL from the site origin", () => {
+    expect(SITE_URL).toBe("https://www.neilmillard.com");
+    expect(canonicalUrl("/terms/")).toBe("https://www.neilmillard.com/terms/");
+    expect(canonicalUrl("/")).toBe("https://www.neilmillard.com/");
+  });
+});

--- a/src/app/tests/sitemap.test.ts
+++ b/src/app/tests/sitemap.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, test} from "@jest/globals";
+import sitemap from "@/app/sitemap";
+import {getAllBlogPosts} from "@/lib/blogs";
+import {SITE_URL} from "@/lib/site";
+
+describe("sitemap", () => {
+  test("every entry is an absolute, trailing-slash URL on the canonical origin", () => {
+    const entries = sitemap();
+
+    expect(entries.length).toBeGreaterThan(0);
+    entries.forEach((entry) => {
+      expect(entry.url.startsWith(SITE_URL)).toBe(true);
+      expect(entry.url).toMatch(/\/$/);
+    });
+  });
+
+  test("includes the static pages flagged in Search Console", () => {
+    const urls = sitemap().map((entry) => entry.url);
+
+    expect(urls).toContain(`${SITE_URL}/terms/`);
+    expect(urls).toContain(`${SITE_URL}/contact/`);
+    expect(urls).toContain(`${SITE_URL}/`);
+  });
+
+  test("includes every blog post", () => {
+    const urls = sitemap().map((entry) => entry.url);
+    const posts = getAllBlogPosts();
+
+    posts.forEach((post) => {
+      expect(urls).toContain(`${SITE_URL}/blog/${post.id}/`);
+    });
+  });
+});

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,5 @@
+export const SITE_URL = "https://www.neilmillard.com";
+
+export function canonicalUrl(path: string): string {
+  return `${SITE_URL}${path}`;
+}


### PR DESCRIPTION
## Summary
Follow-up to #46 (merged), which fixed `Footer`/`DeploysComponent` links missing a trailing slash. `trailingSlash: true` in `next.config.ts` is correct and stays. This PR closes the remaining gaps requested against DEL-81's fuller scope:

**1. More internal links without a trailing slash**
- `BlogNav.tsx` prev/next links, and the `blog/newest` / `blog/oldest` post listing links (next/link already normalizes these at build time given `trailingSlash: true` — verified via a real `next build` — but the literal source values were inconsistent with the rest of the site, so made them explicit).

**2. `/blog/` redirect hop**
- `NavBar`'s "Blog" nav item and `BlogNav`'s center "Blog" link both pointed at `/blog/`, which itself immediately client-redirects to `/blog/newest/` — an unnecessary hop on every page view. Both now point straight at `/blog/newest/`.

**3. No canonical tags, no sitemap.xml**
- Added `metadataBase` + per-page `alternates.canonical` (via `generateMetadata` for blog posts) across every route, so `<link rel="canonical">` matches the served trailing-slash URL everywhere.
- Added `src/app/sitemap.ts`, emitting every static page and blog post as an absolute, trailing-slash URL.
- `clock/page.tsx` was a client component and can't export `metadata`, so it's now split into a server page + a new `ClockPageClient` component for the interactive bits.

## Test plan
- [x] TDD: wrote failing tests first for every change (`canonical.test.ts`, `sitemap.test.ts`, `NavBar`/`BlogNav`/`SortLinks`/`BlogListPages` link tests, `site.test.ts`), confirmed red, then made them pass
- [x] `npx jest` — all 64 tests pass
- [x] `npx eslint` — no errors (one pre-existing unrelated warning)
- [x] `next build` + inspected `out/`: `<link rel="canonical">` present and correct on every static page and a sampled blog post; `sitemap.xml` has 138 entries, all trailing-slash; no first-party link anywhere in the built HTML resolves to a redirect (`/blog/` no longer linked from nav)

Once merged and deployed, resubmit `/terms` and `/contact` in Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
