### PR TITLE
DEL-160: Add robots.txt and llms.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,19 @@
+# Neil Millard
+
+> Neil Millard is a speaker, author, and DevOps/platform engineering consultant. He helps businesses adopt cloud and automated infrastructure, drawing on years of experience in the financial sector (Barclays, Lloyds, AXA) and as a conference speaker.
+
+This site is a personal blog and portfolio covering DevOps, cloud infrastructure (AWS, Cloudflare), automation, and technical leadership.
+
+## Key pages
+
+- [About](https://www.neilmillard.com/about/): Background, experience, and speaking history.
+- [Blog](https://www.neilmillard.com/blog/): Articles on DevOps, AWS, automation, and technical debt, dating back to 2015.
+- [DevOps](https://www.neilmillard.com/devops/): Overview of DevOps consulting and services offered.
+- [Glossary](https://www.neilmillard.com/glossary/): Definitions of common DevOps and cloud terminology.
+- [Book](https://www.neilmillard.com/book/): Book by Neil Millard.
+- [Contact](https://www.neilmillard.com/contact/): How to get in touch.
+
+## Notes
+
+- Blog posts are written in Markdown and rendered as static HTML; each post is available at `/blog/<slug>/`.
+- [Terms](https://www.neilmillard.com/terms/) and [Privacy](https://www.neilmillard.com/privacy/) pages cover site policies.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,41 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /

--- a/src/app/tests/StaticSeoFiles.test.ts
+++ b/src/app/tests/StaticSeoFiles.test.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+import {describe, test, expect} from "@jest/globals";
+
+const publicDir = path.join(__dirname, "../../../public");
+
+describe("robots.txt", () => {
+  const content = fs.readFileSync(path.join(publicDir, "robots.txt"), "utf-8");
+
+  test("allows all crawlers by default", () => {
+    expect(content).toMatch(/User-agent: \*[\s\S]*?Allow: \//);
+  });
+
+  test("explicitly allows known AI crawlers", () => {
+    for (const bot of ["GPTBot", "ClaudeBot", "anthropic-ai", "Google-Extended", "CCBot", "PerplexityBot"]) {
+      expect(content).toContain(`User-agent: ${bot}`);
+    }
+  });
+
+  test("does not disallow any AI crawler", () => {
+    expect(content).not.toMatch(/Disallow/);
+  });
+});
+
+describe("llms.txt", () => {
+  const content = fs.readFileSync(path.join(publicDir, "llms.txt"), "utf-8");
+
+  test("starts with an H1 title", () => {
+    expect(content.split("\n")[0]).toMatch(/^# /);
+  });
+
+  test("links to key site pages", () => {
+    for (const href of ["/about/", "/blog/", "/devops/", "/contact/"]) {
+      expect(content).toContain(href);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `public/robots.txt` allowing all crawlers by default, with explicit `Allow` entries for well-known AI crawlers (GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, anthropic-ai, Claude-User, Google-Extended, CCBot, PerplexityBot, Perplexity-User, Bytespider, Applebot/Applebot-Extended)
- Adds `public/llms.txt` per the llms.txt convention: a curated Markdown summary of the site (About, Blog, DevOps, Glossary, Book, Contact) with links
- Both live in `public/` so `next build`'s static export copies them verbatim to the site root
- Adds `src/app/tests/StaticSeoFiles.test.ts` asserting both files exist and contain the expected content

Closes DEL-160

## Test plan
- [x] `npm test` — all 20 suites / 47 tests pass including the new file
- [x] `npx eslint .` — no new issues
- [x] `npm run build` — verified `out/robots.txt` and `out/llms.txt` are present after export
- [ ] After merge/deploy, verify `https://www.neilmillard.com/robots.txt` and `https://www.neilmillard.com/llms.txt` are served in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)