### PR TITLE
DEL-202: Fix duplicate/too-short meta descriptions across pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,10 @@
 import AboutComponent from "@/app/components/AboutComponent";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About Neil Millard | DevOps Speaker & Author",
+  description: "Neil Millard is a DevOps speaker, author and consultant with 20+ years in cloud, automation and platform engineering, from startups to enterprise clients.",
+};
 
 export default function About() {
     return <AboutComponent />

--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -1,4 +1,6 @@
+import type {Metadata} from "next";
 import {getAdjacentBlogPosts, getAllBlogPosts, getBlogPost} from "@/lib/blogs";
+import {buildMetaDescription} from "@/lib/seo";
 import BlogPost, {BlogPostShort} from "@/app/components/blog/BlogPost";
 import {BlogNav} from "@/app/components/blog/BlogNav";
 import ContactForm from "@/app/components/ContactForm";
@@ -9,6 +11,17 @@ const BLOG_CONTACT_FRAMING: Record<string, string> = {
   "2026-06-28-do-you-really-need-kubernetes":
     "ECS or Kubernetes — still not sure which fits your team? Tell me about your setup and I'll give you an honest answer.",
 };
+
+export async function generateMetadata({ params, }: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const {id} = await params;
+  const blog = await getBlogPost(id);
+  return {
+    title: `${blog.title} | Neil Millard`,
+    description: buildMetaDescription(blog.content),
+  };
+}
 
 export default async function BlogPage({ params, }: {
   params: Promise<{ id: string }>

--- a/src/app/blog/newest/page.tsx
+++ b/src/app/blog/newest/page.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import {getAllBlogPosts} from "@/lib/blogs";
 import SortLinks from "@/app/components/blog/SortLinks";
+
+export const metadata: Metadata = {
+  title: "Blog Posts, Newest First | Neil Millard",
+  description: "Browse Neil Millard's blog posts on DevOps, cloud infrastructure and platform engineering, sorted newest first.",
+};
 
 export default function BlogIndex() {
   const blogs = getAllBlogPosts("newest");

--- a/src/app/blog/oldest/page.tsx
+++ b/src/app/blog/oldest/page.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import {getAllBlogPosts} from "@/lib/blogs";
 import SortLinks from "@/app/components/blog/SortLinks";
+
+export const metadata: Metadata = {
+  title: "Blog Posts, Oldest First | Neil Millard",
+  description: "Browse Neil Millard's blog posts on DevOps, cloud infrastructure and platform engineering, sorted oldest first.",
+};
 
 export default function BlogIndex() {
   const blogs = getAllBlogPosts("oldest");

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,4 +1,10 @@
 import BookComponent from "@/app/components/BookComponent";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Who Moved My Servers? | Book by Neil Millard",
+  description: "Who Moved My Servers? by Neil Millard is a guide to surviving and thriving through cloud migration and DevOps transformation. Available in paperback and Kindle.",
+};
 
 export default function Book() {
     return <BookComponent />

--- a/src/app/clock/page.tsx
+++ b/src/app/clock/page.tsx
@@ -1,40 +1,11 @@
-"use client";
-import ClockComponent from "@/app/components/ClockComponent";
-import {useState} from "react";
-import TimerComponent from "@/app/components/TimerComponent";
+import type { Metadata } from "next";
+import ClockPageClient from "@/app/components/ClockPageClient";
+
+export const metadata: Metadata = {
+  title: "Clock & Timer Tool | Neil Millard",
+  description: "A simple online clock and countdown timer tool from Neil Millard, useful for timeboxing talks, workshops and DevOps retrospectives.",
+};
 
 export default function Clock() {
-  const [isTimerMode, setIsTimerMode] = useState<boolean>(false);
-  const handleClockMode = () => {
-    setIsTimerMode(false);
-  }
-  const handleTimerMode = () => {
-    setIsTimerMode(true);
-  }
-  const clockButtonReadyClass = isTimerMode ? "bg-green-500 hover:bg-green-600" : "bg-gray-500 hover:bg-gray-600";
-  const timerButtonReadyClass = isTimerMode ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600";
-
-  return (
-    <div className="flex flex-col items-center justify-center h-full">
-      <div className="flex space-x-4 pt-4">
-        <button
-          className={timerButtonReadyClass + " text-white font-bold py-2 px-8 rounded-lg text-xl"}
-          onClick={handleClockMode}
-        >
-          Clock
-        </button>
-        <button
-          className={clockButtonReadyClass + " text-white font-bold py-2 px-8 rounded-lg text-xl"}
-          onClick={handleTimerMode}
-        >
-          Timer
-        </button>
-      </div>
-      {!isTimerMode ? (
-        <ClockComponent/>
-      ) : (
-        <TimerComponent/>
-      )}
-    </div>
-  )
+  return <ClockPageClient/>
 }

--- a/src/app/components/ClockPageClient.tsx
+++ b/src/app/components/ClockPageClient.tsx
@@ -1,0 +1,40 @@
+"use client";
+import ClockComponent from "@/app/components/ClockComponent";
+import {useState} from "react";
+import TimerComponent from "@/app/components/TimerComponent";
+
+export default function ClockPageClient() {
+  const [isTimerMode, setIsTimerMode] = useState<boolean>(false);
+  const handleClockMode = () => {
+    setIsTimerMode(false);
+  }
+  const handleTimerMode = () => {
+    setIsTimerMode(true);
+  }
+  const clockButtonReadyClass = isTimerMode ? "bg-green-500 hover:bg-green-600" : "bg-gray-500 hover:bg-gray-600";
+  const timerButtonReadyClass = isTimerMode ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600";
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <div className="flex space-x-4 pt-4">
+        <button
+          className={timerButtonReadyClass + " text-white font-bold py-2 px-8 rounded-lg text-xl"}
+          onClick={handleClockMode}
+        >
+          Clock
+        </button>
+        <button
+          className={clockButtonReadyClass + " text-white font-bold py-2 px-8 rounded-lg text-xl"}
+          onClick={handleTimerMode}
+        >
+          Timer
+        </button>
+      </div>
+      {!isTimerMode ? (
+        <ClockComponent/>
+      ) : (
+        <TimerComponent/>
+      )}
+    </div>
+  )
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,10 @@
 import ContactPage from "@/app/components/ContactForm";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contact Neil Millard",
+  description: "Get in touch with Neil Millard to discuss DevOps consulting, team training, speaking engagements or a bookable session for you or your engineering team.",
+};
 
 export default function Contact() {
     return <ContactPage apiUrl={"/api/contact"}/>

--- a/src/app/deploys/page.tsx
+++ b/src/app/deploys/page.tsx
@@ -1,4 +1,10 @@
 import DeploysComponent from "@/app/components/DeploysComponent";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Deployment Strategies | Neil Millard",
+  description: "Learn effective deployment strategies with Neil Millard: blue-green, canary and rolling releases explained, with practical guidance for your projects.",
+};
 
 export default function Deploys() {
     return <DeploysComponent />

--- a/src/app/devops/page.tsx
+++ b/src/app/devops/page.tsx
@@ -1,4 +1,10 @@
 import DevOpsComponent from "@/app/components/DevOpsComponent";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "DevOps Services | Neil Millard",
+  description: "DevOps consulting, training and mentoring from Neil Millard: build automated deployment pipelines and adopt platform engineering best practice for your team.",
+};
 
 export default function DevOps() {
     return <DevOpsComponent />

--- a/src/app/glossary/page.tsx
+++ b/src/app/glossary/page.tsx
@@ -1,4 +1,10 @@
 import GlossaryComponent from "@/app/components/GlossaryComponent";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "DevOps Glossary | Neil Millard",
+  description: "A plain-English glossary of DevOps, cloud and platform engineering terms, compiled by Neil Millard to help teams speak the same technical language.",
+};
 
 export default function Glossary() {
     return <GlossaryComponent />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "Neil Millard",
-  description: "Blog, Speaker, Author, Contracting and DevOps",
+  description: "Neil Millard is a DevOps speaker, author and consultant helping engineering teams build automated, resilient cloud infrastructure and ship with confidence.",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,11 @@
 import React from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Neil Millard | DevOps Speaker, Author & Consultant",
+  description: "Neil Millard helps engineering teams ship faster with DevOps consulting, training and speaking. Over 20 years building automated, resilient infrastructure.",
+};
 
 export default function Home() {
   const services = [

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Neil Millard",
+  description: "Read the privacy policy for neilmillard.com, covering what information is collected, how it is used, and your rights over your personal data.",
+};
+
 export default function Privacy() {
   return (
     <div className="w-[83%] mx-auto p-8 bg-white rounded-2xl shadow-md mt-10 mb-10">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Neil Millard",
+  description: "Terms of service for neilmillard.com, covering use of the site, continuous deployment consulting services, liability and intellectual property.",
+};
+
 export default function Terms() {
   return (
     <div className="w-[83%] mx-auto p-8 bg-white rounded-2xl shadow-md mt-10 mb-10">

--- a/src/app/tests/BlogPostMetadata.test.ts
+++ b/src/app/tests/BlogPostMetadata.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect, jest, beforeAll } from "@jest/globals";
+import type { generateMetadata as GenerateMetadata } from "@/app/blog/[id]/page";
+
+describe("blog post generateMetadata", () => {
+  let generateMetadata: typeof GenerateMetadata;
+
+  beforeAll(async () => {
+    jest.doMock("@/lib/blogs", () => ({
+      getBlogPost: jest.fn(() =>
+        Promise.resolve({
+          id: "test-post",
+          title: "Do You Really Need Kubernetes?",
+          date: "2026-06-28",
+          content: "# Do you really need Kubernetes?\n\nMost teams reach for Kubernetes before they've outgrown a simpler setup, and pay for it in complexity for years.",
+          image: null,
+        })
+      ),
+      getAdjacentBlogPosts: jest.fn(() => ({ previous: null, next: null })),
+      getAllBlogPosts: jest.fn(() => []),
+    }));
+
+    ({ generateMetadata } = await import("@/app/blog/[id]/page"));
+  });
+
+  test("builds a unique title and description from the post content", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ id: "test-post" }) });
+
+    expect(metadata.title).toBe("Do You Really Need Kubernetes? | Neil Millard");
+    expect(metadata.description).toContain("Most teams reach for Kubernetes");
+    expect(metadata.description).not.toContain("#");
+    expect((metadata.description as string).length).toBeLessThanOrEqual(160);
+  });
+});

--- a/src/app/tests/seo.test.ts
+++ b/src/app/tests/seo.test.ts
@@ -1,0 +1,41 @@
+import { buildMetaDescription } from '@/lib/seo';
+
+describe('buildMetaDescription', () => {
+  test('strips markdown formatting and returns plain text', () => {
+    const content = '# Heading\n\nThis is **bold** and _italic_ text with a [link](https://example.com).';
+    const result = buildMetaDescription(content);
+
+    expect(result).not.toMatch(/[#*_\][]/);
+    expect(result).toContain('link');
+    expect(result).not.toContain('https://example.com');
+  });
+
+  test('strips images, code fences and HTML tags', () => {
+    const content = '![alt text](/img/pic.png)\n\n```js\nconst x = 1;\n```\n\n<div>Some <strong>content</strong></div> after the code.';
+    const result = buildMetaDescription(content);
+
+    expect(result).not.toContain('![');
+    expect(result).not.toContain('```');
+    expect(result).not.toMatch(/<\/?[a-z]+>/i);
+    expect(result).toContain('Some content after the code.');
+  });
+
+  test('returns short content unchanged (aside from whitespace collapse)', () => {
+    const content = 'A short sentence about DevOps.';
+    expect(buildMetaDescription(content)).toBe('A short sentence about DevOps.');
+  });
+
+  test('truncates long content to the max length on a word boundary with an ellipsis', () => {
+    const content = 'word '.repeat(60).trim();
+    const result = buildMetaDescription(content, 155);
+
+    expect(result.length).toBeLessThanOrEqual(156);
+    expect(result.endsWith('…')).toBe(true);
+    expect(result.slice(0, -1)).toMatch(/^(word )*word$/); // only ever cuts on whole words, never mid-word
+  });
+
+  test('collapses repeated whitespace and newlines into single spaces', () => {
+    const content = 'Line one.\n\n\nLine   two.';
+    expect(buildMetaDescription(content)).toBe('Line one. Line two.');
+  });
+});

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,22 @@
+// Builds a unique, search-engine-friendly meta description from raw markdown/HTML content
+// by stripping formatting and truncating to a target length on a word boundary.
+export function buildMetaDescription(content: string, maxLength = 155): string {
+  const plain = content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/!\[.*?]\(.*?\)/g, ' ')
+    .replace(/\[([^\]]+)]\([^)]+\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#*_>`~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (plain.length <= maxLength) {
+    return plain;
+  }
+
+  const truncated = plain.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cut = lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated;
+
+  return cut.trim().replace(/[.,;:]+$/, '') + '…';
+}


### PR DESCRIPTION
## Summary
- Every page previously inherited the root layout's single 47-char description ("Blog, Speaker, Author, Contracting and DevOps") since no page defined its own `metadata`, so every page had a duplicate, too-short meta description.
- Added unique, ~150-160 char `metadata` (title + description) to every static page: home, about, devops, book, contact, glossary, privacy, terms, deploys, clock, blog/newest, blog/oldest.
- Added a `buildMetaDescription` helper (`src/lib/seo.ts`) that strips markdown/HTML and truncates on a word boundary, used in a new `generateMetadata` for `blog/[id]/page.tsx` so each of the 126 blog posts now gets a unique description built from its own content instead of sharing one.
- `clock/page.tsx` was a client component (`"use client"`), which can't export `metadata`; split its UI into `ClockPageClient` so the page itself can stay a server component with metadata.

## Test plan
- [x] `npx jest` — all 67 tests pass, including new tests for `buildMetaDescription` and blog post `generateMetadata`
- [x] `npx eslint .` — no errors (one pre-existing unrelated warning)
- [x] `npx tsc --noEmit` — clean
- [x] `npx next build` — builds successfully, all 126 blog post pages statically generated with per-post metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)