### PR TITLE
DEL-206: remove techanswers.club links

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -18,7 +18,6 @@ export function Footer() {
       href="https://www.helpfulmoney.site" target="_blank" className="hover:text-gray-300">Finance Tools</a> - <a
       href="https://www.facebook.com/neil.millard/" target="_blank" className="hover:text-gray-300">Facebook</a> - <a
       href="https://www.youtube.com/channel/UCAaoh3jk1qtvD3ALPp48_8w" target="_blank" className="hover:text-gray-300">YouTube channel</a> - <a
-      href="https://www.techanswers.club/" target="_blank" className="hover:text-gray-300">Tech Answers Club</a> - <a
       href="/clock/" className="hover:text-gray-300">Clock</a> - <a
       href="https://www.deltafamiglia.com/" className="hover:text-gray-300">Delta Famiglia Ltd</a>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,11 +10,6 @@ export const metadata: Metadata = {
 export default function Home() {
   const services = [
     {
-      title: "Build knowledge",
-      description: "Build an effective team. Q&A sessions. Free public sessions or Private sessions, it's up to you!",
-      link: "https://www.techanswers.club"
-    },
-    {
       title: "Train your team",
       description: "I can upskill and mentor your team.",
       link: "/blog/2017-03-25-6-steps-to-cloud-expert/"

--- a/src/app/tests/HomePage.test.tsx
+++ b/src/app/tests/HomePage.test.tsx
@@ -14,7 +14,6 @@ describe("HomePage", () => {
     expect(screen.getByText("Services")).toBeInTheDocument();
 
     // Check if some of the services are rendered
-    expect(screen.getByText("Build knowledge")).toBeInTheDocument();
     expect(screen.getByText("Train your team")).toBeInTheDocument();
 
     cleanup();


### PR DESCRIPTION
## Summary
- Removes the "Tech Answers Club" footer link (techanswers.club is deprecated)
- Removes the "Build knowledge" services card, which linked to techanswers.club
- Updates the HomePage test that asserted on the removed card

## Test plan
- [x] `npm test` — all 23 suites / 67 tests pass