### PR TITLE
DEL-248: fix broken /public/img, legacy permalink, and /tags/ links

### DIFF
--- a/_posts/2017-06-10-puppet-camp-london-june-2017.md
+++ b/_posts/2017-06-10-puppet-camp-london-june-2017.md
@@ -38,7 +38,7 @@ Of course support for Puppet 3 is now deprecated, so I'll be updating my example
       caption="Video of presentation" %}
 
 The biggest challenges with this approach are;
-i) [Immutable](/tags/#immutable) servers don't change, this means should any configuration or software needs to be updated, you will have to rebuild the server.
+i) Immutable servers don't change, this means should any configuration or software needs to be updated, you will have to rebuild the server.
 In Development this is no big issue, especially if those environments are rebuilt daily. After all, no point paying for a server or environment when your developers are tucked up in bed.
 ii) The puppet code is usually only run once, on boot. This means intrusion detection needs to be factored into the design, as you cannot rely on puppet to revert edited files, malicious or not.
 Again regular rebuilds can reduce this issue, but active monitoring of all instances is a must.

--- a/_posts/2017-08-19-what-is-devops.md
+++ b/_posts/2017-08-19-what-is-devops.md
@@ -58,7 +58,7 @@ I provide easy to use services that enable any member of your organisation to bu
 
 This means I provide three main things;
 
-1) An easy to use interface to allow Developers to ask for [freshly built servers](https://www.neilmillard.com/tags/#immutable) in the cloud and get what you want; as easy as ordering a book from Amazon.
+1) An easy to use interface to allow Developers to ask for freshly built servers in the cloud and get what you want; as easy as ordering a book from Amazon.
 
 2) When your server is created, it is ready to be used as quickly as possible; the software and more importantly, [your data is available from where you left off](https://www.neilmillard.com/2017/03/18/persistent-data-docker-and-cloud/).
 In the case of a multi server deployment, all servers’ data is synchronised.

--- a/src/app/tests/blogs.test.ts
+++ b/src/app/tests/blogs.test.ts
@@ -64,6 +64,38 @@ describe('replaceLegacySiteUrls', () => {
 
     expect(replaceLegacySiteUrls(content)).toBe(content);
   });
+
+  test('rewrites a bare legacy Jekyll permalink (no site.url token) to the current blog route', () => {
+    const content = 'See <a href="/2019/01/25/four-steps-automate.html">this post</a>.';
+
+    const result = replaceLegacySiteUrls(content);
+
+    expect(result).toBe('See <a href="/blog/2019-01-25-four-steps-automate/">this post</a>.');
+  });
+
+  test('rewrites a bare /public/img path (no site.url token) to the current /img path', () => {
+    const content = '<img src="/public/img/docker.jpg" alt="x" />';
+
+    const result = replaceLegacySiteUrls(content);
+
+    expect(result).toBe('<img src="/img/docker.jpg" alt="x" />');
+  });
+
+  test('rewrites an absolute-domain /public/img path to the current relative /img path', () => {
+    const content = 'img="https://www.neilmillard.com/public/img/cloudy-sunrise_640.jpg"';
+
+    const result = replaceLegacySiteUrls(content);
+
+    expect(result).toBe('img="/img/cloudy-sunrise_640.jpg"');
+  });
+
+  test('rewrites an absolute-domain (no www) /public/img path to the current relative /img path', () => {
+    const content = 'img="https://neilmillard.com/public/img/wackamole.jpg"';
+
+    const result = replaceLegacySiteUrls(content);
+
+    expect(result).toBe('img="/img/wackamole.jpg"');
+  });
 });
 
 describe('replaceJekyllIncludes', () => {
@@ -123,6 +155,23 @@ describe('rendered blog post content', () => {
       // `{{ var }}` syntax) is intentionally literal, not an unrendered Jekyll/Liquid tag.
       const withoutCodeFences = content.replace(/```[\s\S]*?```/g, '');
       const matches = withoutCodeFences.match(new RegExp(MUSTACHE_TAG_REGEX, 'g'));
+
+      if (matches) {
+        leftovers.push({ id: post.id, matches });
+      }
+    }
+
+    expect(leftovers).toEqual([]);
+  });
+
+  test('every published post is free of broken /public/img, legacy YYYY/MM/DD permalinks, and /tags/ links', async () => {
+    const posts = getAllBlogPosts();
+    const BROKEN_LINK_REGEX = /public\/img\/|\/\d{4}\/\d{2}\/\d{2}\/[\w-]+\.html|\/tags\//;
+    const leftovers: { id: string; matches: string[] }[] = [];
+
+    for (const post of posts) {
+      const { content } = await getBlogPost(post.id);
+      const matches = content.match(new RegExp(BROKEN_LINK_REGEX, 'g'));
 
       if (matches) {
         leftovers.push({ id: post.id, matches });

--- a/src/lib/blogs.ts
+++ b/src/lib/blogs.ts
@@ -43,16 +43,18 @@ export function replaceSiteDataTokens(content: string): string {
     .replace(/{{\s*site\.data\.youtube\.channel\s*}}/g, 'https://www.youtube.com/channel/UCAaoh3jk1qtvD3ALPp48_8w/');
 }
 
-// Function to replace leftover Jekyll `{{ site.url }}` tokens: legacy YYYY/MM/DD/slug.html
-// permalinks -> current /blog/<id>/ routes, /public/img paths -> /img, and any remaining
-// bare token -> the site root.
+// Function to replace legacy YYYY/MM/DD/slug.html permalinks -> current /blog/<id>/ routes,
+// and /public/img paths -> /img, whether they carry a leftover Jekyll `{{ site.url }}` token,
+// the full https://[www.]neilmillard.com domain, or are already relative (all three forms were
+// left behind by the migration away from Jekyll). Any remaining bare `{{ site.url }}` token is
+// replaced with the site root.
 export function replaceLegacySiteUrls(content: string): string {
   return content
     .replace(
-      /{{\s*site\.url\s*}}\/(\d{4})\/(\d{2})\/(\d{2})\/([\w-]+)\.html/g,
+      /(?:{{\s*site\.url\s*}}|https?:\/\/(?:www\.)?neilmillard\.com)?\/(\d{4})\/(\d{2})\/(\d{2})\/([\w-]+)\.html/g,
       (_match, year, month, day, slug) => `/blog/${year}-${month}-${day}-${slug}/`
     )
-    .replace(/{{\s*site\.url\s*}}\/public\/img\//g, '/img/')
+    .replace(/(?:{{\s*site\.url\s*}}|https?:\/\/(?:www\.)?neilmillard\.com)?\/public\/img\//g, '/img/')
     .replace(/{{\s*site\.url\s*}}/g, '/');
 }
 


### PR DESCRIPTION
## Summary
Fixes the 23 broken internal links found by the 18 Aug 2026 Ahrefs 404 crawl (DEL-248).

- `replaceLegacySiteUrls` in `src/lib/blogs.ts` only rewrote `/public/img/...` and `/YYYY/MM/DD/slug.html` links when prefixed with a leftover Jekyll `{{ site.url }}` token. Bare relative links and links with the full `https://[www.]neilmillard.com` domain (both left behind by the Jekyll migration) were never rewritten and 404'd in production. All three forms are now handled.
- Removed two `/tags/#anchor` links (in `2017-06-10-puppet-camp-london-june-2017.md` and `2017-08-19-what-is-devops.md`) — no tags index page exists in the current site, so the anchor text is now unlinked rather than pointing at a 404.
- All 11 missing images from the report exist under `public/img/`; they were 404ing only because of the link-rewriting bug above, not missing files — no image restoration needed.

## Test plan
- [x] Added unit tests in `src/app/tests/blogs.test.ts` for bare and absolute-domain `/public/img/` and legacy permalink rewriting (written first, confirmed red, then fixed).
- [x] Added a site-wide regression test that scans every rendered post for leftover `/public/img/`, legacy `/YYYY/MM/DD/slug.html`, and `/tags/` patterns.
- [x] `npm test` — all 72 tests pass.
- [ ] `npm run lint` / `npm run build` could not run in this environment (Node 18.19.1 present, Next.js requires >=20.9.0) — pre-existing environment limitation, unrelated to this change.