### PR TITLE
Fix duplicate <title> tags on neilmillard.com (DEL-250)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,6 @@ export default function RootLayout({
       <meta property="og:url" content="https://www.neilmillard.com" />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Neil Millard" />
-      <title>Neil Millard, Speaker, Author, DevOps</title>
     </head>
     <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}

--- a/src/app/tests/RootLayout.test.ts
+++ b/src/app/tests/RootLayout.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("RootLayout head markup", () => {
+  const layoutSource = readFileSync(
+    join(__dirname, "../layout.tsx"),
+    "utf-8"
+  );
+
+  test("does not hardcode a <title> tag in the head", () => {
+    // Next's Metadata API already renders <title> from `export const metadata`
+    // (and each page's own metadata/generateMetadata). A hardcoded <title> in
+    // the layout's JSX head renders alongside it, producing two <title> tags
+    // per page.
+    expect(layoutSource).not.toMatch(/<title>/);
+  });
+
+  test("still exports metadata with a site-wide default title", () => {
+    expect(layoutSource).toMatch(/export const metadata: Metadata = {/);
+    expect(layoutSource).toMatch(/title:\s*"Neil Millard"/);
+  });
+});


### PR DESCRIPTION
## Summary
- Ahrefs flagged every indexable page (66 URLs) as rendering two `<title>` tags: a generic hardcoded one in `RootLayout`'s head, and the correct page-specific one from Next's Metadata API.
- Removed the hardcoded `<title>Neil Millard, Speaker, Author, DevOps</title>` from `src/app/layout.tsx`. Next's `export const metadata` (root default, overridden per page via each page's own `metadata`/`generateMetadata`) now handles the title alone.

## Test plan
- [x] Added `src/app/tests/RootLayout.test.ts` (TDD: written first, confirmed red) asserting the layout source no longer hardcodes a `<title>` tag and still exports a default site-wide title via the Metadata API.
- [x] `npx jest` — all 24 suites / 74 tests pass.
- [x] `npx eslint src/app/layout.tsx src/app/tests/RootLayout.test.ts` — clean.
- [x] `npx next build` — spot-checked generated HTML for `/`, `/about`, `/devops`: exactly one document `<title>` per page (the page-specific one); remaining `<title>` matches are unrelated SVG icon accessibility titles.

DEL-250 (parent DEL-249 has the full Ahrefs CSV of affected URLs).