### PR TITLE
DEL-261: Fix GA4 tag using wrong Next.js third-parties component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import React from "react";
-import { GoogleTagManager } from "@next/third-parties/google"
+import { GoogleAnalytics } from "@next/third-parties/google"
 import {NavBar} from "@/app/components/NavBar";
 import {Footer} from "@/app/components/Footer";
 
@@ -42,7 +42,7 @@ export default function RootLayout({
     <div className='h-10'></div>
     {children}
     <Footer/>
-    <GoogleTagManager gtmId="G-C5CKFSXQSX" />
+    <GoogleAnalytics gaId="G-C5CKFSXQSX" />
     </body>
     </html>
   );

--- a/src/app/tests/RootLayout.test.ts
+++ b/src/app/tests/RootLayout.test.ts
@@ -19,4 +19,17 @@ describe("RootLayout head markup", () => {
     expect(layoutSource).toMatch(/export const metadata: Metadata = {/);
     expect(layoutSource).toMatch(/title:\s*"Neil Millard"/);
   });
+
+  test("uses the GoogleAnalytics component for the GA4 measurement ID", () => {
+    // G-C5CKFSXQSX is a GA4 measurement ID, not a GTM container ID (GTM-XXXXXXX).
+    // The GoogleTagManager component loads gtm.js, which never calls
+    // gtag('js', ...) / gtag('config', ...) for a GA4 ID — that's the mismatch
+    // Google's compliance warning flagged. GoogleAnalytics loads gtag.js and
+    // calls gtag('config', gaId) directly, which is the supported method.
+    expect(layoutSource).toMatch(
+      /import\s*{\s*GoogleAnalytics\s*}\s*from\s*"@next\/third-parties\/google"/
+    );
+    expect(layoutSource).toMatch(/<GoogleAnalytics gaId="G-C5CKFSXQSX"\s*\/>/);
+    expect(layoutSource).not.toMatch(/GoogleTagManager/);
+  });
 });


### PR DESCRIPTION
## Summary
- Google flagged tag `G-C5CKFSXQSX` with a compliance warning. `G-C5CKFSXQSX` is a **GA4 measurement ID** (prefix `G-`), not a GTM container ID (prefix `GTM-`), but `src/app/layout.tsx` passed it to the `GoogleTagManager` component from `@next/third-parties/google`.
- `GoogleTagManager` loads `gtm.js`, which never calls `gtag('js', new Date())` or `gtag('config', 'G-...')` — this mismatch is exactly what Google's supported-implementation check (https://support.google.com/tagmanager/answer/17231523) flags.
- Switched to the `GoogleAnalytics` component, which loads `gtag.js` and calls `gtag('config', gaId)` directly — the supported method for GA4 measurement IDs.

## Test plan
- [x] Added a test asserting `layout.tsx` uses `GoogleAnalytics` with `gaId="G-C5CKFSXQSX"` and does not reference `GoogleTagManager`
- [x] `npx jest` — all 75 tests pass
- [x] `npx eslint src/app/layout.tsx src/app/tests/RootLayout.test.ts` — clean
- [x] `npm run build` — production build succeeds
- [ ] Verify the Google Analytics property warning clears after deploy (external verification, cannot be done from this environment)