### PR TITLE
DEL-316: add og:image site default and per-post images

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -1,6 +1,8 @@
 import type {Metadata} from "next";
 import {getAdjacentBlogPosts, getAllBlogPosts, getBlogPost} from "@/lib/blogs";
-import {buildMetaDescription} from "@/lib/seo";
+import {buildMetaDescription, extractFirstImage} from "@/lib/seo";
+
+const DEFAULT_OG_IMAGE = "/img/2024-03-14-DevOps_Excellence_Awards_NeilMillard_Large.jpg";
 import BlogPost, {BlogPostShort} from "@/app/components/blog/BlogPost";
 import {BlogNav} from "@/app/components/blog/BlogNav";
 import ContactForm from "@/app/components/ContactForm";
@@ -17,9 +19,18 @@ export async function generateMetadata({ params, }: {
 }): Promise<Metadata> {
   const {id} = await params;
   const blog = await getBlogPost(id);
+  const description = buildMetaDescription(blog.content);
+  const image = blog.image ?? extractFirstImage(blog.content) ?? DEFAULT_OG_IMAGE;
+
   return {
     title: `${blog.title} | Neil Millard`,
-    description: buildMetaDescription(blog.content),
+    description,
+    openGraph: {
+      title: `${blog.title} | Neil Millard`,
+      description,
+      type: "article",
+      images: [{url: image}],
+    },
   };
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,9 +16,21 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const SITE_URL = "https://www.neilmillard.com";
+const DEFAULT_OG_IMAGE = "/img/2024-03-14-DevOps_Excellence_Awards_NeilMillard_Large.jpg";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Neil Millard",
   description: "Neil Millard is a DevOps speaker, author and consultant helping engineering teams build automated, resilient cloud infrastructure and ship with confidence.",
+  openGraph: {
+    title: "Neil Millard",
+    description: "Neil Millard. Blog, Speaker, Author, Contracting and DevOps",
+    url: SITE_URL,
+    siteName: "Neil Millard",
+    type: "website",
+    images: [{url: DEFAULT_OG_IMAGE, width: 1024, height: 683}],
+  },
 };
 
 export default function RootLayout({
@@ -28,13 +40,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-    <head>
-      <meta property="og:title" content="Neil Millard" />
-      <meta property="og:description" content="Neil Millard. Blog, Speaker, Author, Contracting and DevOps" />
-      <meta property="og:url" content="https://www.neilmillard.com" />
-      <meta property="og:type" content="website" />
-      <meta property="og:site_name" content="Neil Millard" />
-    </head>
     <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
     >

--- a/src/app/tests/BlogPostMetadata.test.ts
+++ b/src/app/tests/BlogPostMetadata.test.ts
@@ -30,4 +30,74 @@ describe("blog post generateMetadata", () => {
     expect(metadata.description).not.toContain("#");
     expect((metadata.description as string).length).toBeLessThanOrEqual(160);
   });
+
+  test("falls back to the site default og:image when the post has no image", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ id: "test-post" }) });
+
+    expect(metadata.openGraph?.images).toEqual([
+      expect.objectContaining({ url: "/img/2024-03-14-DevOps_Excellence_Awards_NeilMillard_Large.jpg" }),
+    ]);
+  });
+});
+
+describe("blog post generateMetadata with a frontmatter image", () => {
+  let generateMetadata: typeof GenerateMetadata;
+
+  beforeAll(async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/blogs", () => ({
+      getBlogPost: jest.fn(() =>
+        Promise.resolve({
+          id: "test-post-with-image",
+          title: "Kubernetes vs ECS",
+          date: "2026-06-28",
+          content: "Some content with no inline images.",
+          image: "/img/kubernetes-vs-ecs.png",
+        })
+      ),
+      getAdjacentBlogPosts: jest.fn(() => ({ previous: null, next: null })),
+      getAllBlogPosts: jest.fn(() => []),
+    }));
+
+    ({ generateMetadata } = await import("@/app/blog/[id]/page"));
+  });
+
+  test("uses the post's frontmatter image for og:image", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ id: "test-post-with-image" }) });
+
+    expect(metadata.openGraph?.images).toEqual([
+      expect.objectContaining({ url: "/img/kubernetes-vs-ecs.png" }),
+    ]);
+  });
+});
+
+describe("blog post generateMetadata with an inline content image", () => {
+  let generateMetadata: typeof GenerateMetadata;
+
+  beforeAll(async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/blogs", () => ({
+      getBlogPost: jest.fn(() =>
+        Promise.resolve({
+          id: "test-post-with-inline-image",
+          title: "A Post With An Inline Image",
+          date: "2026-06-28",
+          content: "Intro text.\n\n![a diagram](/img/diagram.png)\n\nMore text.",
+          image: null,
+        })
+      ),
+      getAdjacentBlogPosts: jest.fn(() => ({ previous: null, next: null })),
+      getAllBlogPosts: jest.fn(() => []),
+    }));
+
+    ({ generateMetadata } = await import("@/app/blog/[id]/page"));
+  });
+
+  test("falls back to the first image found in the post content", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ id: "test-post-with-inline-image" }) });
+
+    expect(metadata.openGraph?.images).toEqual([
+      expect.objectContaining({ url: "/img/diagram.png" }),
+    ]);
+  });
 });

--- a/src/app/tests/RootLayout.test.ts
+++ b/src/app/tests/RootLayout.test.ts
@@ -20,6 +20,19 @@ describe("RootLayout head markup", () => {
     expect(layoutSource).toMatch(/title:\s*"Neil Millard"/);
   });
 
+  test("does not hardcode og: meta tags in the head", () => {
+    // These now live in `openGraph` on the Metadata export, which Next
+    // renders itself — a hardcoded <meta property="og:..."> in the JSX head
+    // would duplicate them (and never included og:image in the first place).
+    expect(layoutSource).not.toMatch(/<meta property="og:/);
+  });
+
+  test("exports a site-wide default og:image via openGraph.images", () => {
+    expect(layoutSource).toMatch(/openGraph:\s*{/);
+    expect(layoutSource).toMatch(/images:\s*\[{\s*url:\s*DEFAULT_OG_IMAGE/);
+    expect(layoutSource).toMatch(/metadataBase:\s*new URL\(SITE_URL\)/);
+  });
+
   test("uses the GoogleAnalytics component for the GA4 measurement ID", () => {
     // G-C5CKFSXQSX is a GA4 measurement ID, not a GTM container ID (GTM-XXXXXXX).
     // The GoogleTagManager component loads gtm.js, which never calls

--- a/src/app/tests/seo.test.ts
+++ b/src/app/tests/seo.test.ts
@@ -1,4 +1,4 @@
-import { buildMetaDescription } from '@/lib/seo';
+import { buildMetaDescription, extractFirstImage } from '@/lib/seo';
 
 describe('buildMetaDescription', () => {
   test('strips markdown formatting and returns plain text', () => {
@@ -37,5 +37,27 @@ describe('buildMetaDescription', () => {
   test('collapses repeated whitespace and newlines into single spaces', () => {
     const content = 'Line one.\n\n\nLine   two.';
     expect(buildMetaDescription(content)).toBe('Line one. Line two.');
+  });
+});
+
+describe('extractFirstImage', () => {
+  test('finds a standard Markdown image', () => {
+    const content = 'Some intro text.\n\n![a diagram](/img/diagram.png)\n\nMore text.';
+    expect(extractFirstImage(content)).toBe('/img/diagram.png');
+  });
+
+  test('finds an ImageWrapper JSX image when there is no Markdown image', () => {
+    const content = 'Intro.\n\n<ImageWrapper img="/img/wrapper-pic.jpg" caption="x" />\n\nOutro.';
+    expect(extractFirstImage(content)).toBe('/img/wrapper-pic.jpg');
+  });
+
+  test('prefers the first Markdown image over a later ImageWrapper image', () => {
+    const content = '![first](/img/first.png)\n\n<ImageWrapper img="/img/second.jpg" />';
+    expect(extractFirstImage(content)).toBe('/img/first.png');
+  });
+
+  test('returns null when the content has no images', () => {
+    const content = 'Just plain text with no pictures at all.';
+    expect(extractFirstImage(content)).toBeNull();
   });
 });

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -20,3 +20,21 @@ export function buildMetaDescription(content: string, maxLength = 155): string {
 
   return cut.trim().replace(/[.,;:]+$/, '') + '…';
 }
+
+// Finds the first image referenced in a post's (already-processed) content, checking
+// standard Markdown image syntax first and falling back to the ImageWrapper JSX tag
+// left behind by replaceImageIncludes, so a per-post og:image can be derived without
+// requiring every post to carry an explicit `image:` frontmatter field.
+export function extractFirstImage(content: string): string | null {
+  const markdownMatch = content.match(/!\[.*?]\(([^)]+)\)/);
+  if (markdownMatch) {
+    return markdownMatch[1];
+  }
+
+  const wrapperMatch = content.match(/<ImageWrapper[^>]*\bimg="([^"]+)"/);
+  if (wrapperMatch) {
+    return wrapperMatch[1];
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Ahrefs flagged no `og:image` on neilmillard.com. Root layout previously hardcoded `og:title`/`og:description`/`og:url`/`og:site_name` via raw `<meta>` tags and never set `og:image`.
- Root layout now moves all OG tags into Next's `openGraph` metadata field (adds `metadataBase` + a site-wide default `images` entry), so Next renders `og:image`, `og:image:width/height`, and derives `twitter:image` automatically for every page.
- Blog post pages (`generateMetadata`) now set a per-post `og:image`: uses the post's frontmatter `image` field if set, otherwise the first image found in the post's markdown content, otherwise the site default.
- Added `extractFirstImage` helper in `src/lib/seo.ts` for the content-image fallback.

Verified with `next build` that the generated HTML for both the homepage and a blog post contains an absolute `og:image` URL (and matching `twitter:image`).

## Test plan
- [x] `npx jest` — all suites pass, including new/updated tests in `RootLayout.test.ts`, `BlogPostMetadata.test.ts`, `seo.test.ts`
- [x] `npx eslint .` — no new warnings/errors
- [x] `npx next build` — static export succeeds; inspected generated HTML for `/` and a blog post to confirm `og:image` renders as an absolute URL with width/height, and `twitter:image` is derived automatically